### PR TITLE
Update bulkadd.js

### DIFF
--- a/bulkadd.js
+++ b/bulkadd.js
@@ -26,7 +26,7 @@ function bulkadd() {
     }
 
     for (var i = 0; i < files.length; i++) {
-        var sound = track.addSound(parameter, 'SingleSound', i + 1, 1);
+        var sound = track.addSound(parameter, 'SingleSound', i + 1, 0.5);
         sound.audioFile = files[i];
     }
 }


### PR DESCRIPTION
Hey hope you're doing well!

This small value change accounts for other splitting programs (like reaper) that don't fade out the audio files.
after some testing it seems to have no detectable downside/no effect on the intended auto splitter workflow.